### PR TITLE
want both src. and source, dst. and destination metrics

### DIFF
--- a/syslog_ng_exporter.go
+++ b/syslog_ng_exporter.go
@@ -166,14 +166,14 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) error {
 		log.Debugf("Successfully parsed STATS line: %v", stat)
 
 		switch stat.objectType[0:4] {
-		case "src.":
+		case "src.", "sour":
 			switch stat.metric {
 			case "processed":
 				ch <- prometheus.MustNewConstMetric(e.srcProcessed, prometheus.CounterValue,
 					stat.value, stat.objectType, stat.id, stat.instance)
 			}
 
-		case "dst.":
+		case "dst.", "dest":
 			switch stat.metric {
 			case "dropped":
 				ch <- prometheus.MustNewConstMetric(e.dstDropped, prometheus.CounterValue,


### PR DESCRIPTION
I can't find it documented, but it looks like 'src.' and 'dst.' are just for internal sources and destinations.

Manually specified ones show up as 'source' and 'destination' in the stats - updating this exporter to gather those as well.  Slightly hacky in that I'm sticking with just checking the first 4 characters, so 'sour' and 'dest'.