### PR TITLE
Add in recognition of more complex inputs.

### DIFF
--- a/syslog_ng_exporter.go
+++ b/syslog_ng_exporter.go
@@ -173,6 +173,13 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) error {
 					stat.value, stat.objectType, stat.id, stat.instance)
 			}
 
+		case "sour":
+			switch stat.metric {
+			case "processed":
+				ch <- prometheus.MustNewConstMetric(e.srcProcessed, prometheus.CounterValue,
+					stat.value, stat.objectType, stat.id, stat.instance)
+			}
+
 		case "dst.":
 			switch stat.metric {
 			case "dropped":


### PR DESCRIPTION
There are cases where some sources are not recognised, I think because the input has a channel inside the source.

For example;

```
source s_syslog_tcp {
  channel {
    source {
      network( port(514) transport("tcp")
        tags("syslog_ng", "syslog_tcp", "unprocessed")
        flags(dont-store-legacy-msghdr,syslog-protocol)
      );
    };
    rewrite {
      set("tcp", value("syslog_transport"));
      set("false", value("processed"));
      set("${S_UNIXTIME}", value("unixtime"));
    };
  };
};
```
The only output from syslog-ng-stats is;
```
syslog-ng-ctl stats | grep s_syslog_tcp
source;s_syslog_tcp;;a;processed;11428093
```
It parses pretty much the same as a normal source.